### PR TITLE
Remove unsafe code and some features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "storagevec"
-version = "0.1.6"
+version = "0.2.0"
 authors = ["not_a_seagull <jtnunley01@gmail.com>"]
 edition = "2018"
 description = "Feature-gated heap-based/stack-based map and vector structures."

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,9 +6,8 @@
 //! The idea behind this crate is to allow crates that require vector or map types to be able
 //! to be `no_std` by allowing heap storage to be toggled on or off via features.
 
-#![cfg_attr(all(feature = "alloc", not(feature = "stack")), forbid(unsafe_code))]
+#![forbid(unsafe_code)]
 #![feature(min_const_generics)]
-#![feature(maybe_uninit_uninit_array)]
 #![no_std]
 #![warn(clippy::pedantic)]
 #![allow(clippy::redundant_pattern_matching)] // i try to avoid generating a lot of LLVM IR in order

--- a/src/svec.rs
+++ b/src/svec.rs
@@ -150,7 +150,7 @@ impl<T: Default, const N: usize> StorageVec<T, N> {
     #[cfg(not(feature = "alloc"))]
     #[inline]
     fn try_insert_impl(&mut self, item: T, index: usize) -> Result<(), T> {
-        match (self.0).0.try_insert(index, UninitContainer::new(item)) {
+        match (self.0).0.try_insert(index, item) {
             None => Ok(()),
             Some(reject) => Err(reject),
         }
@@ -245,6 +245,7 @@ impl<T: Default, const N: usize> Iterator for StorageVecIterator<T, N> {
 
 impl<T: Default, const N: usize> ExactSizeIterator for StorageVecIterator<T, N> {}
 
+#[cfg(not(feature = "stack"))]
 impl<T: Default, const N: usize> DoubleEndedIterator for StorageVecIterator<T, N> {
     #[inline]
     fn next_back(&mut self) -> Option<T> {


### PR DESCRIPTION
This pull request changes the API in two notable ways:

* Adds `#![forbid_unsafe]` and purges all unsafe usage of `MaybeUninit`. As a downside, this crate requires its elements to implement `Default`.
* Removes the need to use `#![feature(maybe_uninit_uninit_array)]`, meaning that the only unstable feature this crate relies on is `min_const_generics`.